### PR TITLE
Stop modal opening when clicking a link in the DataTable

### DIFF
--- a/frontend/src/components/DataTable.vue
+++ b/frontend/src/components/DataTable.vue
@@ -26,7 +26,10 @@ var sortBy = ref({
     sortDirection: SortDirection.Ascending
 });
 
-function openModal(entry: DataEntryType) {
+function openModal(entry: DataEntryType, $event: MouseEvent) {
+    if ($event.target instanceof Element && $event.target.tagName.toLowerCase() === "a") {
+        return;
+    } 
     currentData.value = entry;
     modalRef.value.showModal();
 }
@@ -109,7 +112,7 @@ function sorted(prop: DataEntryKey, ascending: SortDirection) {
                 </tr>
             </thead>
             <tbody>
-                <tr v-for="entry in dataEntries" v-on:click="openModal(entry)"
+                <tr v-for="entry in dataEntries" v-on:click="openModal(entry, $event)"
                     class="bg-white border-b hover:bg-gray-100 cursor-pointer">
                     <th v-for="key in visibleKeys" scope="row"
                         class="px-6 py-4 font-medium max-w-6 text-gray-900 whitespace-nowrap">


### PR DESCRIPTION
This PR stops the modal from opening when a link is clicked in the DataTable. The fix is pretty straight-forward: when an entry is clicked, and if the target element of the click-event is a `a`-tag, don't open the modal.

The only other non-standard thing is that one also needs to verify that `$event.target` is an instance of the `Element`-class, which I think always is the case anyway. (I don't think it's possible for anything other than an `Element` to be the target of a click-event.